### PR TITLE
Adjusting order of XML elements to match the UPnP Device Architecture 1....

### DIFF
--- a/core/src/main/java/org/fourthline/cling/binding/xml/UDA10DeviceDescriptorBinderImpl.java
+++ b/core/src/main/java/org/fourthline/cling/binding/xml/UDA10DeviceDescriptorBinderImpl.java
@@ -396,7 +396,6 @@ public class UDA10DeviceDescriptorBinderImpl implements DeviceDescriptorBinder {
         Element deviceElement = appendNewElement(descriptor, rootElement, ELEMENT.device);
 
         appendNewElementIfNotNull(descriptor, deviceElement, ELEMENT.deviceType, deviceModel.getType());
-        appendNewElementIfNotNull(descriptor, deviceElement, ELEMENT.UDN, deviceModel.getIdentity().getUdn());
 
         DeviceDetails deviceModelDetails = deviceModel.getDetails(info);
         appendNewElementIfNotNull(
@@ -435,6 +434,7 @@ public class UDA10DeviceDescriptorBinderImpl implements DeviceDescriptorBinder {
                 descriptor, deviceElement, ELEMENT.serialNumber,
                 deviceModelDetails.getSerialNumber()
         );
+        appendNewElementIfNotNull(descriptor, deviceElement, ELEMENT.UDN, deviceModel.getIdentity().getUdn());
         appendNewElementIfNotNull(
                 descriptor, deviceElement, ELEMENT.presentationURL,
                 deviceModelDetails.getPresentationURI()
@@ -494,14 +494,14 @@ public class UDA10DeviceDescriptorBinderImpl implements DeviceDescriptorBinder {
             appendNewElementIfNotNull(descriptor, serviceElement, ELEMENT.serviceId, service.getServiceId());
             if (service instanceof RemoteService) {
                 RemoteService rs = (RemoteService) service;
+                appendNewElementIfNotNull(descriptor, serviceElement, ELEMENT.SCPDURL, rs.getDescriptorURI());
                 appendNewElementIfNotNull(descriptor, serviceElement, ELEMENT.controlURL, rs.getControlURI());
                 appendNewElementIfNotNull(descriptor, serviceElement, ELEMENT.eventSubURL, rs.getEventSubscriptionURI());
-                appendNewElementIfNotNull(descriptor, serviceElement, ELEMENT.SCPDURL, rs.getDescriptorURI());
             } else if (service instanceof LocalService) {
                 LocalService ls = (LocalService) service;
+                appendNewElementIfNotNull(descriptor, serviceElement, ELEMENT.SCPDURL, namespace.getDescriptorPath(ls));
                 appendNewElementIfNotNull(descriptor, serviceElement, ELEMENT.controlURL, namespace.getControlPath(ls));
                 appendNewElementIfNotNull(descriptor, serviceElement, ELEMENT.eventSubURL, namespace.getEventSubscriptionPath(ls));
-                appendNewElementIfNotNull(descriptor, serviceElement, ELEMENT.SCPDURL, namespace.getDescriptorPath(ls));
             }
         }
     }

--- a/core/src/main/java/org/fourthline/cling/binding/xml/UDA10ServiceDescriptorBinderImpl.java
+++ b/core/src/main/java/org/fourthline/cling/binding/xml/UDA10ServiceDescriptorBinderImpl.java
@@ -412,10 +412,10 @@ public class UDA10ServiceDescriptorBinderImpl implements ServiceDescriptorBinder
 
         appendNewElementIfNotNull(descriptor, actionArgumentElement, ELEMENT.name, actionArgument.getName());
         appendNewElementIfNotNull(descriptor, actionArgumentElement, ELEMENT.direction, actionArgument.getDirection().toString().toLowerCase());
-        appendNewElementIfNotNull(descriptor, actionArgumentElement, ELEMENT.relatedStateVariable, actionArgument.getRelatedStateVariableName());
         if (actionArgument.isReturnValue()) {
             appendNewElement(descriptor, actionArgumentElement, ELEMENT.retval);
         }
+        appendNewElementIfNotNull(descriptor, actionArgumentElement, ELEMENT.relatedStateVariable, actionArgument.getRelatedStateVariableName());
     }
 
     private void generateServiceStateTable(Service serviceModel, Document descriptor, Element scpdElement) {


### PR DESCRIPTION
...1 XML schema.

cling implements UPnP 1.0.

Whilst the UPnP Device Architecture 1.0 document doesn't provide a full XML schema, the
1.1 document does so. It's available from:
http://upnp.org/sdcps-and-certification/standards/device-architecture-documents/

In Appendix B1 it gives the full schema for a UPnP device, and in Appendix B2 for
a UPnP service.

The order of XML elements is important in this schemas, since nearly all of the
parent elements are defined as sequences with fixed order.

This change amends cling to match the order given in these two appendices.
Since cling is implementing UPnP 1.0, it shouldn't really matter, but we know
of at least one UPnP stack which insists that the order of elements is the same
as given in this 1.1 schema, even if the UPnP version in use is 1.0.
(This stack is somehow based upon GUPnP and Qt, but we don't have full visibility
of its internals - we just want to make cling work with it!)

Specifically this change:
- Moves the UDN into the right place in the device XML.
- Moves the SCPDURL into the right place in the device XML.
- Moves the 'relatedStateVariable' into the right place in the service XML.
