### PR TITLE
Cling fails on android/java platforms whose Locale is set to Turk

### DIFF
--- a/core/src/main/java/org/fourthline/cling/binding/annotations/AnnotationLocalServiceBinder.java
+++ b/core/src/main/java/org/fourthline/cling/binding/annotations/AnnotationLocalServiceBinder.java
@@ -47,6 +47,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.Locale;
 import java.util.logging.Logger;
 
 /**
@@ -256,14 +257,14 @@ public class AnnotationLocalServiceBinder implements LocalServiceBinder {
         if (javaName.length() < 1) {
             throw new IllegalArgumentException("Variable name must be at least 1 character long");
         }
-        return javaName.substring(0, 1).toUpperCase() + javaName.substring(1);
+        return javaName.substring(0, 1).toUpperCase(Locale.ENGLISH) + javaName.substring(1);
     }
 
     static String toJavaStateVariableName(String upnpName) {
         if (upnpName.length() < 1) {
             throw new IllegalArgumentException("Variable name must be at least 1 character long");
         }
-        return upnpName.substring(0, 1).toLowerCase() + upnpName.substring(1);
+        return upnpName.substring(0, 1).toLowerCase(Locale.ENGLISH) + upnpName.substring(1);
     }
 
 
@@ -271,14 +272,14 @@ public class AnnotationLocalServiceBinder implements LocalServiceBinder {
         if (javaName.length() < 1) {
             throw new IllegalArgumentException("Action name must be at least 1 character long");
         }
-        return javaName.substring(0, 1).toUpperCase() + javaName.substring(1);
+        return javaName.substring(0, 1).toUpperCase(Locale.ENGLISH) + javaName.substring(1);
     }
 
     static String toJavaActionName(String upnpName) {
         if (upnpName.length() < 1) {
             throw new IllegalArgumentException("Variable name must be at least 1 character long");
         }
-        return upnpName.substring(0, 1).toLowerCase() + upnpName.substring(1);
+        return upnpName.substring(0, 1).toLowerCase(Locale.ENGLISH) + upnpName.substring(1);
     }
 
 }

--- a/core/src/main/java/org/fourthline/cling/binding/xml/UDA10ServiceDescriptorBinderImpl.java
+++ b/core/src/main/java/org/fourthline/cling/binding/xml/UDA10ServiceDescriptorBinderImpl.java
@@ -43,6 +43,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.logging.Logger;
 
 import static org.fourthline.cling.binding.xml.Descriptor.Service.ATTRIBUTE;
@@ -236,7 +237,7 @@ public class UDA10ServiceDescriptorBinderImpl implements ServiceDescriptorBinder
             if (ELEMENT.name.equals(argumentNodeChild)) {
                 actionArgument.name = XMLUtil.getTextContent(argumentNodeChild);
             } else if (ELEMENT.direction.equals(argumentNodeChild)) {
-                actionArgument.direction = ActionArgument.Direction.valueOf(XMLUtil.getTextContent(argumentNodeChild).toUpperCase());
+                actionArgument.direction = ActionArgument.Direction.valueOf(XMLUtil.getTextContent(argumentNodeChild).toUpperCase(Locale.ENGLISH));
             } else if (ELEMENT.relatedStateVariable.equals(argumentNodeChild)) {
                 actionArgument.relatedStateVariable = XMLUtil.getTextContent(argumentNodeChild);
             } else if (ELEMENT.retval.equals(argumentNodeChild)) {
@@ -266,7 +267,7 @@ public class UDA10ServiceDescriptorBinderImpl implements ServiceDescriptorBinder
 
         stateVariable.eventDetails = new StateVariableEventDetails(
                 stateVariableElement.getAttribute("sendEvents") != null &&
-                        stateVariableElement.getAttribute(ATTRIBUTE.sendEvents.toString()).toUpperCase().equals("YES")
+                        stateVariableElement.getAttribute(ATTRIBUTE.sendEvents.toString()).toUpperCase(Locale.ENGLISH).equals("YES")
         );
 
         NodeList stateVariableChildren = stateVariableElement.getChildNodes();
@@ -411,7 +412,7 @@ public class UDA10ServiceDescriptorBinderImpl implements ServiceDescriptorBinder
         Element actionArgumentElement = appendNewElement(descriptor, actionElement, ELEMENT.argument);
 
         appendNewElementIfNotNull(descriptor, actionArgumentElement, ELEMENT.name, actionArgument.getName());
-        appendNewElementIfNotNull(descriptor, actionArgumentElement, ELEMENT.direction, actionArgument.getDirection().toString().toLowerCase());
+        appendNewElementIfNotNull(descriptor, actionArgumentElement, ELEMENT.direction, actionArgument.getDirection().toString().toLowerCase(Locale.ENGLISH));
         if (actionArgument.isReturnValue()) {
             appendNewElement(descriptor, actionArgumentElement, ELEMENT.retval);
         }

--- a/core/src/main/java/org/fourthline/cling/binding/xml/UDA10ServiceDescriptorBinderSAXImpl.java
+++ b/core/src/main/java/org/fourthline/cling/binding/xml/UDA10ServiceDescriptorBinderSAXImpl.java
@@ -36,6 +36,7 @@ import org.xml.sax.SAXException;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.logging.Logger;
 
 import static org.fourthline.cling.binding.xml.Descriptor.Service.ATTRIBUTE;
@@ -238,7 +239,7 @@ public class UDA10ServiceDescriptorBinderSAXImpl extends UDA10ServiceDescriptorB
                     getInstance().name = getCharacters();
                     break;
                 case direction:
-                    getInstance().direction = ActionArgument.Direction.valueOf(getCharacters().toUpperCase());
+                    getInstance().direction = ActionArgument.Direction.valueOf(getCharacters().toUpperCase(Locale.ENGLISH));
                     break;
                 case relatedStateVariable:
                     getInstance().relatedStateVariable = getCharacters();
@@ -270,7 +271,7 @@ public class UDA10ServiceDescriptorBinderSAXImpl extends UDA10ServiceDescriptorB
 
                 String sendEventsAttributeValue = attributes.getValue(ATTRIBUTE.sendEvents.toString());
                 stateVariable.eventDetails = new StateVariableEventDetails(
-                        sendEventsAttributeValue != null && sendEventsAttributeValue.toUpperCase().equals("YES")
+                        sendEventsAttributeValue != null && sendEventsAttributeValue.toUpperCase(Locale.ENGLISH).equals("YES")
                 );
 
                 getInstance().add(stateVariable);

--- a/core/src/main/java/org/fourthline/cling/model/ModelUtil.java
+++ b/core/src/main/java/org/fourthline/cling/model/ModelUtil.java
@@ -22,6 +22,7 @@ import java.net.NetworkInterface;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Set;
+import java.util.Locale;
 
 /**
  * Shared trivial procedures.
@@ -86,7 +87,7 @@ public class ModelUtil {
         if (ANDROID_RUNTIME) {
             return name != null && name.length() != 0;
         }
-        return name != null && name.length() != 0 && !name.toLowerCase().startsWith("xml") && name.matches(Constants.REGEX_UDA_NAME);
+        return name != null && name.length() != 0 && !name.toLowerCase(Locale.ENGLISH).startsWith("xml") && name.matches(Constants.REGEX_UDA_NAME);
     }
 
     /**

--- a/core/src/main/java/org/fourthline/cling/model/message/UpnpRequest.java
+++ b/core/src/main/java/org/fourthline/cling/model/message/UpnpRequest.java
@@ -22,6 +22,7 @@ import java.net.URL;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Locale;
 
 /**
  * A request message, with a method (GET, POST, NOTIFY, etc).
@@ -58,7 +59,7 @@ public class UpnpRequest extends UpnpOperation {
 
         public static Method getByHttpName(String httpName) {
             if (httpName == null) return UNKNOWN;
-        	Method m = byName.get(httpName.toUpperCase());
+        	Method m = byName.get(httpName.toUpperCase(Locale.ENGLISH));
             return m != null ? m : UNKNOWN;
         }
     }

--- a/core/src/main/java/org/fourthline/cling/model/message/header/MaxAgeHeader.java
+++ b/core/src/main/java/org/fourthline/cling/model/message/header/MaxAgeHeader.java
@@ -21,6 +21,7 @@ import org.fourthline.cling.model.Constants;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.Locale;
 
 /**
  * @author Christian Bauer
@@ -40,7 +41,7 @@ public class MaxAgeHeader extends UpnpHeader<Integer> {
 
     public void setString(String s) throws InvalidHeaderException {
 
-        Matcher matcher = MAX_AGE_REGEX.matcher(s.toLowerCase());
+        Matcher matcher = MAX_AGE_REGEX.matcher(s.toLowerCase(Locale.ENGLISH));
         if (!matcher.matches()){
             throw new InvalidHeaderException("Invalid cache-control value, can't parse max-age seconds: " + s);
         }

--- a/core/src/main/java/org/fourthline/cling/model/message/header/NTEventHeader.java
+++ b/core/src/main/java/org/fourthline/cling/model/message/header/NTEventHeader.java
@@ -17,6 +17,8 @@
 
 package org.fourthline.cling.model.message.header;
 
+import java.util.Locale;
+
 /**
  * @author Christian Bauer
  */
@@ -27,7 +29,7 @@ public class NTEventHeader extends UpnpHeader<String> {
     }
 
     public void setString(String s) throws InvalidHeaderException {
-        if (!s.toLowerCase().equals(getValue())) {
+        if (!s.toLowerCase(Locale.ENGLISH).equals(getValue())) {
             throw new InvalidHeaderException("Invalid event NT header value: " + s);
         }
     }

--- a/core/src/main/java/org/fourthline/cling/model/message/header/RootDeviceHeader.java
+++ b/core/src/main/java/org/fourthline/cling/model/message/header/RootDeviceHeader.java
@@ -17,6 +17,8 @@
 
 package org.fourthline.cling.model.message.header;
 
+import java.util.Locale;
+
 /**
  * @author Christian Bauer
  */
@@ -27,7 +29,7 @@ public class RootDeviceHeader extends UpnpHeader<String> {
     }
 
     public void setString(String s) throws InvalidHeaderException {
-        if (!s.toLowerCase().equals(getValue())) {
+        if (!s.toLowerCase(Locale.ENGLISH).equals(getValue())) {
             throw new InvalidHeaderException("Invalid root device NT header value: " + s);
         }
     }

--- a/core/src/main/java/org/fourthline/cling/model/message/header/UpnpHeader.java
+++ b/core/src/main/java/org/fourthline/cling/model/message/header/UpnpHeader.java
@@ -21,6 +21,7 @@ import org.seamless.util.Exceptions;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -123,7 +124,7 @@ public abstract class UpnpHeader<T> {
          */
         public static Type getByHttpName(String httpName) {
             if (httpName == null) return null;
-        	return byName.get(httpName.toUpperCase());
+        	return byName.get(httpName.toUpperCase(Locale.ENGLISH));
         }
     }
 

--- a/core/src/main/java/org/fourthline/cling/model/types/BooleanDatatype.java
+++ b/core/src/main/java/org/fourthline/cling/model/types/BooleanDatatype.java
@@ -17,6 +17,8 @@
 
 package org.fourthline.cling.model.types;
 
+import java.util.Locale;
+
 /**
  * @author Christian Bauer
  */
@@ -32,9 +34,9 @@ public class BooleanDatatype extends AbstractDatatype<Boolean> {
 
     public Boolean valueOf(String s) throws InvalidValueException {
         if (s.equals("")) return null;
-        if (s.equals("1") || s.toUpperCase().equals("YES") || s.toUpperCase().equals("TRUE")) {
+        if (s.equals("1") || s.toUpperCase(Locale.ENGLISH).equals("YES") || s.toUpperCase(Locale.ENGLISH).equals("TRUE")) {
             return true;
-        } else if (s.equals("0") || s.toUpperCase().equals("NO") || s.toUpperCase().equals("FALSE")) {
+        } else if (s.equals("0") || s.toUpperCase(Locale.ENGLISH).equals("NO") || s.toUpperCase(Locale.ENGLISH).equals("FALSE")) {
             return false;
         } else {
             throw new InvalidValueException("Invalid boolean value string: " + s);

--- a/core/src/main/java/org/fourthline/cling/model/types/Datatype.java
+++ b/core/src/main/java/org/fourthline/cling/model/types/Datatype.java
@@ -20,6 +20,7 @@ package org.fourthline.cling.model.types;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Locale;
 
 /**
  * The type of a state variable value, able to convert to/from string representation.
@@ -142,9 +143,9 @@ public interface Datatype<V> {
         private static Map<String, Builtin> byName = new HashMap<String, Builtin>() {{
             for (Builtin b : Builtin.values()) {
                 // Lowercase descriptor name!
-                if (containsKey(b.getDescriptorName().toLowerCase()))
+                if (containsKey(b.getDescriptorName().toLowerCase(Locale.ENGLISH)))
                     continue; // Ignore double-declarations, take first one only
-                put(b.getDescriptorName().toLowerCase(), b);
+                put(b.getDescriptorName().toLowerCase(Locale.ENGLISH), b);
             }
         }};
 
@@ -170,7 +171,7 @@ public interface Datatype<V> {
             // they are case sensitive. But we want to work with broken devices, which of
             // course produce mixed upper/lowercase values.
             if (descriptorName == null) return null;
-            return byName.get(descriptorName.toLowerCase());
+            return byName.get(descriptorName.toLowerCase(Locale.ENGLISH));
         }
 
         public static boolean isNumeric(Builtin builtin) {

--- a/core/src/main/java/org/fourthline/cling/transport/impl/DatagramProcessorImpl.java
+++ b/core/src/main/java/org/fourthline/cling/transport/impl/DatagramProcessorImpl.java
@@ -34,6 +34,7 @@ import java.io.ByteArrayInputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.DatagramPacket;
 import java.net.InetAddress;
+import java.util.Locale;
 
 /**
  * Default implementation.
@@ -129,7 +130,7 @@ public class DatagramProcessorImpl implements DatagramProcessor {
         // Assemble message
         IncomingDatagramMessage requestMessage;
         UpnpRequest upnpRequest = new UpnpRequest(UpnpRequest.Method.getByHttpName(requestMethod));
-        upnpRequest.setHttpMinorVersion(httpProtocol.toUpperCase().equals("HTTP/1.1") ? 1 : 0);
+        upnpRequest.setHttpMinorVersion(httpProtocol.toUpperCase(Locale.ENGLISH).equals("HTTP/1.1") ? 1 : 0);
         requestMessage = new IncomingDatagramMessage(upnpRequest, datagram.getAddress(), datagram.getPort(), receivedOnAddress);
 
         requestMessage.setHeaders(headers);
@@ -150,7 +151,7 @@ public class DatagramProcessorImpl implements DatagramProcessor {
         // Assemble the message
         IncomingDatagramMessage responseMessage;
         UpnpResponse upnpResponse = new UpnpResponse(statusCode, statusMessage);
-        upnpResponse.setHttpMinorVersion(httpProtocol.toUpperCase().equals("HTTP/1.1") ? 1 : 0);
+        upnpResponse.setHttpMinorVersion(httpProtocol.toUpperCase(Locale.ENGLISH).equals("HTTP/1.1") ? 1 : 0);
         responseMessage = new IncomingDatagramMessage(upnpResponse, datagram.getAddress(), datagram.getPort(), receivedOnAddress);
 
         responseMessage.setHeaders(headers);

--- a/core/src/main/java/org/fourthline/cling/transport/impl/HttpExchangeUpnpStream.java
+++ b/core/src/main/java/org/fourthline/cling/transport/impl/HttpExchangeUpnpStream.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
+import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -77,7 +78,7 @@ public class HttpExchangeUpnpStream extends UpnpStream {
 
             // Protocol
             requestMessage.getOperation().setHttpMinorVersion(
-                    getHttpExchange().getProtocol().toUpperCase().equals("HTTP/1.1") ? 1 : 0
+                    getHttpExchange().getProtocol().toUpperCase(Locale.ENGLISH).equals("HTTP/1.1") ? 1 : 0
             );
 
             log.fine("Created new request message: " + requestMessage);

--- a/core/src/main/java/org/fourthline/cling/transport/impl/NetworkAddressFactoryImpl.java
+++ b/core/src/main/java/org/fourthline/cling/transport/impl/NetworkAddressFactoryImpl.java
@@ -36,6 +36,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -306,18 +307,18 @@ public class NetworkAddressFactoryImpl implements NetworkAddressFactory {
             return false;
         }
 
-        if (iface.getName().toLowerCase().startsWith("vmnet") ||
-        		(iface.getDisplayName() != null &&  iface.getDisplayName().toLowerCase().contains("vmnet"))) {
+        if (iface.getName().toLowerCase(Locale.ENGLISH).startsWith("vmnet") ||
+        		(iface.getDisplayName() != null &&  iface.getDisplayName().toLowerCase(Locale.ENGLISH).contains("vmnet"))) {
             log.finer("Skipping network interface (VMWare): " + iface.getDisplayName());
             return false;
         }
 
-        if (iface.getName().toLowerCase().startsWith("vnic")) {
+        if (iface.getName().toLowerCase(Locale.ENGLISH).startsWith("vnic")) {
             log.finer("Skipping network interface (Parallels): " + iface.getDisplayName());
             return false;
         }
 
-        if (iface.getName().toLowerCase().startsWith("ppp")) {
+        if (iface.getName().toLowerCase(Locale.ENGLISH).startsWith("ppp")) {
             log.finer("Skipping network interface (PPP): " + iface.getDisplayName());
             return false;
         }

--- a/core/src/test/java/org/fourthline/cling/test/model/HeaderParsingTest.java
+++ b/core/src/test/java/org/fourthline/cling/test/model/HeaderParsingTest.java
@@ -30,6 +30,7 @@ import org.seamless.util.MimeType;
 import org.testng.annotations.Test;
 
 import java.net.URI;
+import java.util.Locale;
 
 import static org.testng.Assert.assertEquals;
 
@@ -473,7 +474,7 @@ public class HeaderParsingTest {
     public void parseInterfaceMacAddress() {
         InterfaceMacHeader header = new InterfaceMacHeader("00:17:ab:e9:65:a0");
         assertEquals(header.getValue().length, 6);
-        assertEquals(header.getString().toUpperCase(), "00:17:AB:E9:65:A0");
+        assertEquals(header.getString().toUpperCase(Locale.ENGLISH), "00:17:AB:E9:65:A0");
     }
 
     @Test


### PR DESCRIPTION
Hi, 

I have run into an odd behaviour when using Cling on platforms whose Locale has been set to Turk:

The Turck language has an 'odd' behaviour where the letter 'i' doesn't get converted to 'I' when uppercased, and 'I' doesn't get converted to 'i' when lowercased. You can refer to the java documentation here about this subject:

http://docs.oracle.com/javase/1.5.0/docs/api/java/lang/String.html#toLowerCase(java.util.Locale)

This is also discussed in the ICU documentation here (ICU is backing the android implementation of java Locale):

http://userguide.icu-project.org/transforms/casemappings

As Cling uses toUpperCase() and toLowerCase() here and then when generating xml or parsing the HTTP header, this causes SOAPAction to be converted to SOAPACT??ON for example, or IN to ??n thus preventing a valid request to be processed, or a valid response to be outputed.

I have modified Cling to make sure that everywhere toUpperCase() and toLowerCase() are used, Locale.ENGLISH is used to perform the conversion (considering the UPNP/DLNA and SOAP spec are in english) to make this peculiar issue go away.

Cheers,
Laurent.
