### PR TITLE
make 'socket' protected on MulticastReceiverImpl.java

### DIFF
--- a/core/src/main/java/org/fourthline/cling/transport/impl/MulticastReceiverImpl.java
+++ b/core/src/main/java/org/fourthline/cling/transport/impl/MulticastReceiverImpl.java
@@ -51,7 +51,7 @@ public class MulticastReceiverImpl implements MulticastReceiver<MulticastReceive
 
     protected NetworkInterface multicastInterface;
     protected InetSocketAddress multicastAddress;
-    private MulticastSocket socket;
+    protected MulticastSocket socket;
 
     public MulticastReceiverImpl(MulticastReceiverConfigurationImpl configuration) {
         this.configuration = configuration;


### PR DESCRIPTION
For overriding convenience of the run() method it'd be great if this field was protected, otherwise you also have to override the init() method and re-declare socket, leaving you also open to having two socket instances (if socket is  used elsewher in the class)

I ask because on DatagramIOImpl.java the socket field is protected and it's straightforward to override the run() method.

In case you're wondering why we're overriding datagram receivers, that while (true) is quite aggresive for android devices, we're throttling execution to see if we can reduce cpu consumption and battery usage.

there's also a lot of garbage collection going on on each iteration, we're still investigating if there's a way to make datagram parsing any leaner.
