### PR TITLE
fixed missing ContentType in EventResponses

### DIFF
--- a/core/src/main/java/org/fourthline/cling/model/message/gena/OutgoingEventResponseMessage.java
+++ b/core/src/main/java/org/fourthline/cling/model/message/gena/OutgoingEventResponseMessage.java
@@ -17,6 +17,8 @@ package org.fourthline.cling.model.message.gena;
 
 import org.fourthline.cling.model.message.StreamResponseMessage;
 import org.fourthline.cling.model.message.UpnpResponse;
+import org.fourthline.cling.model.message.header.ContentTypeHeader;
+import org.fourthline.cling.model.message.header.UpnpHeader;
 
 /**
  * @author Christian Bauer
@@ -25,9 +27,11 @@ public class OutgoingEventResponseMessage extends StreamResponseMessage {
 
     public OutgoingEventResponseMessage() {
         super(new UpnpResponse(UpnpResponse.Status.OK));
+        getHeaders().add(UpnpHeader.Type.CONTENT_TYPE, new ContentTypeHeader());
     }
 
     public OutgoingEventResponseMessage(UpnpResponse operation) {
         super(operation);
+        getHeaders().add(UpnpHeader.Type.CONTENT_TYPE, new ContentTypeHeader());
     }
 }


### PR DESCRIPTION
Some devices (wemo) stop notification when a content type is missing in responses to notifications.
Specification says ContentType is required.
