### PR TITLE
Crash fix UpnpServiceImpl.java

### DIFF
--- a/core/src/main/java/org/fourthline/cling/UpnpServiceImpl.java
+++ b/core/src/main/java/org/fourthline/cling/UpnpServiceImpl.java
@@ -165,7 +165,7 @@ public class UpnpServiceImpl implements UpnpService {
             if (cause instanceof InterruptedException) {
                 log.log(Level.INFO, "Router shutdown was interrupted: " + ex, cause);
             } else {
-                throw new RuntimeException("Router error on shutdown: " + ex, ex);
+                log.log(Level.SEVERE, "Router error on shutdown: " + ex, cause);
             }
         }
     }


### PR DESCRIPTION
People keep experiencing a floating bug on the network message router shutdown, couldn't catch it by myself till today. It appears very rarely, but when it does, my app crashes. Here is the stacktrace:

FATAL EXCEPTION: Thread-9066
    java.lang.RuntimeException: Router error on shutdown: org.fourthline.cling.transport.RouterException: Router wasn't available exclusively after waiting 15000ms, lock failed: WriteLock
            at org.fourthline.cling.UpnpServiceImpl.shutdownRouter(UpnpServiceImpl.java:168)
            at org.fourthline.cling.UpnpServiceImpl$1.run(UpnpServiceImpl.java:143)
            at java.lang.Thread.run(Thread.java:856)
     Caused by: org.fourthline.cling.transport.RouterException: Router wasn't available exclusively after waiting 15000ms, lock failed: WriteLock
            at org.fourthline.cling.transport.RouterImpl.lock(RouterImpl.java:497)
            at org.fourthline.cling.transport.RouterImpl.lock(RouterImpl.java:510)
            at org.fourthline.cling.android.AndroidRouter.disable(AndroidRouter.java:108)
            at org.fourthline.cling.transport.RouterImpl.shutdown(RouterImpl.java:199)
            at org.fourthline.cling.android.AndroidRouter.shutdown(AndroidRouter.java:83)
            at org.fourthline.cling.UpnpServiceImpl.shutdownRouter(UpnpServiceImpl.java:162)
            at org.fourthline.cling.UpnpServiceImpl$1.run(UpnpServiceImpl.java:143)
            at java.lang.Thread.run(Thread.java:856)

Test environment: XBMC server for Windows, Samsung Galaxy S4 (Android 4.2.2)

It appears on Android, can't tell for other platforms. Will be much appreciated, if you could apply this workaround sometime soon. 

Thanks in advance!
