### PR TITLE
Add API to add/remove connectors of a running jetty server

### DIFF
--- a/core/src/main/java/org/fourthline/cling/transport/impl/AsyncServletStreamServerImpl.java
+++ b/core/src/main/java/org/fourthline/cling/transport/impl/AsyncServletStreamServerImpl.java
@@ -46,6 +46,7 @@ public class AsyncServletStreamServerImpl implements StreamServer<AsyncServletSt
 
     final protected AsyncServletStreamServerConfigurationImpl configuration;
     protected int localPort;
+    protected String hostAddress;
 
     public AsyncServletStreamServerImpl(AsyncServletStreamServerConfigurationImpl configuration) {
         this.configuration = configuration;
@@ -63,8 +64,9 @@ public class AsyncServletStreamServerImpl implements StreamServer<AsyncServletSt
             );
 
             log.info("Adding connector: " + bindAddress + ":" + getConfiguration().getListenPort());
+            hostAddress = bindAddress.getHostAddress();
             localPort = getConfiguration().getServletContainerAdapter().addConnector(
-                bindAddress.getHostAddress(),
+                hostAddress,
                 getConfiguration().getListenPort()
             );
 
@@ -81,7 +83,7 @@ public class AsyncServletStreamServerImpl implements StreamServer<AsyncServletSt
     }
 
     synchronized public void stop() {
-        getConfiguration().getServletContainerAdapter().stopIfRunning();
+        getConfiguration().getServletContainerAdapter().removeConnector(hostAddress, localPort);
     }
 
     public void run() {

--- a/core/src/main/java/org/fourthline/cling/transport/spi/ServletContainerAdapter.java
+++ b/core/src/main/java/org/fourthline/cling/transport/spi/ServletContainerAdapter.java
@@ -61,6 +61,15 @@ public interface ServletContainerAdapter {
     int addConnector(String host, int port) throws IOException;
 
     /**
+     * Removes a previously added connector. Implementation should close the corresponding 
+     * listening server socket. It may stop the server when the last connector is removed.
+     *
+     * @param host The host address of the socket.
+     * @param port The port of the connector
+     */
+    void removeConnector(String host, int port);
+
+    /**
      * Might be called several times to register (the same) handler for UPnP
      * requests, should only register it once.
      *


### PR DESCRIPTION
Patch the ServletContainerAdapter to allow adding/removing listening sockets while the servlet container is running.

This is to allow a custom router implementation to dynamically add or remove network interfaces without having to restart the stream server (this keeps open subscriptions actives)

JettyServletContainer is modified to implement this feature

Modified code is exercised by existing tests.
