### PR TITLE
Updated Android dependencies

### DIFF
--- a/demo/android/browser/pom.xml
+++ b/demo/android/browser/pom.xml
@@ -15,7 +15,7 @@
     <build>
 		<plugins>
             <plugin>
-                <groupId>com.jayway.maven.plugins.android.generation2</groupId>
+                <groupId>com.simpligility.maven.plugins</groupId>
                 <artifactId>android-maven-plugin</artifactId>
                 <version>${android.maven.plugin.version}</version>
             </plugin>

--- a/demo/android/light/pom.xml
+++ b/demo/android/light/pom.xml
@@ -15,7 +15,7 @@
     <build>
 		<plugins>
             <plugin>
-                <groupId>com.jayway.maven.plugins.android.generation2</groupId>
+                <groupId>com.simpligility.maven.plugins</groupId>
                 <artifactId>android-maven-plugin</artifactId>
                 <version>${android.maven.plugin.version}</version>
             </plugin>

--- a/demo/android/pom.xml
+++ b/demo/android/pom.xml
@@ -22,7 +22,7 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>com.jayway.maven.plugins.android.generation2</groupId>
+                    <groupId>com.simpligility.maven.plugins</groupId>
                     <artifactId>android-maven-plugin</artifactId>
                     <version>${android.maven.plugin.version}</version>
                     <extensions>true</extensions>
@@ -56,15 +56,12 @@
             <groupId>org.seamless</groupId>
             <artifactId>seamless-android</artifactId>
             <version>${seamless.version}</version>
+            <type>aar</type>
             <!-- Not needed for FixedAndroidLoggingHandler -->
             <exclusions>
                 <exclusion>
-                    <groupId>com.android.support</groupId>
-                    <artifactId>support-v4</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.android.support</groupId>
-                    <artifactId>support-v13</artifactId>
+                    <groupId>android.support</groupId>
+                    <artifactId>compatibility-v13</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -86,8 +86,8 @@
         <apache.httpcomponents.httpclient.version>4.2.2</apache.httpcomponents.httpclient.version>
         <apache.httpcomponents.httpcore.version>4.2.3</apache.httpcomponents.httpcore.version>
         <android.version>4.0.1.2</android.version>
-        <android.maven.plugin.version>4.0.0-rc.1</android.maven.plugin.version>
-        <jetty.version>8.1.8.v20121106</jetty.version>
+        <android.maven.plugin.version>4.0.0-rc.3</android.maven.plugin.version>
+        <jetty.version>8.1.16.v20140903</jetty.version>
         <cdi.api.version>1.0-SP4</cdi.api.version>
         <ejb.api.version>3.0</ejb.api.version>
         <slf4j.version>1.6.1</slf4j.version>


### PR DESCRIPTION
Updates a few Android dependencies (Jetty, Maven Plugin) and switches to the .aar version of the seamless package.
More info why apklib is deprecated: https://code.google.com/p/maven-android-plugin/wiki/ApkLib

Should only be merged, once https://github.com/4thline/seamless/pull/6 is merged & re-released to maven (switched to .aar format).
