### PR TITLE
Connectors should check their local port on removal

### DIFF
--- a/core/src/main/java/org/fourthline/cling/transport/impl/jetty/JettyServletContainer.java
+++ b/core/src/main/java/org/fourthline/cling/transport/impl/jetty/JettyServletContainer.java
@@ -99,7 +99,7 @@ public class JettyServletContainer implements ServletContainerAdapter {
     synchronized public void removeConnector(String host, int port)  {
         Connector[] connectors = server.getConnectors();
         for (Connector connector : connectors) {
-            if (connector.getHost().equals(host) && connector.getPort() == port) {
+            if (connector.getHost().equals(host) && connector.getLocalPort() == port) {
                 if (connector.isStarted() || connector.isStarting()) {
                     try {
                         connector.stop();


### PR DESCRIPTION
This fixes a connectivity problem when stopping & starting services.

Here is what worked/didn't work:
First I built a device:
```
localDevice = mediaServer.buildDevice();
upnpService.getRegistry().addDevice(localDevice, new DiscoveryOptions(true, true));
```

Then checked out the active stream server network interfaces:

```
final List<NetworkAddress> servers = upnpService.get().getRouter().getActiveStreamServers(null);
final NetworkAddress address = servers.get(0);
final String targetHost = address.getAddress().getHostAddress();
final int targetPort = address.getPort() + 1;

log.log(Level.FINEST, "MediaServer: {0}:{1,number,#}", new Object[]{targetHost, targetPort - 1});
```

When I ran `curl` on that host & port, it properly returned some 404 message from Jetty.

Afterwards, I removed the device:
```
upnpService.getRegistry().removeDevice(localDevice);
```

When running `curl` again, it was simply hanging / waiting for response. It should have received "Connection refused" right away.

~~@christianbauer I suppose this is only a surface-level fix. The question is why the connector is returning 0 in the `getPort()` method.~~

@christianbauer question remains whether usage of the localPort is correct. It seems to be correct during my tests now as well. Thanks @kevinshine .