### PR TITLE
add explicit descriptor name for ICON

### DIFF
--- a/support/src/main/java/org/fourthline/cling/support/model/DIDLObject.java
+++ b/support/src/main/java/org/fourthline/cling/support/model/DIDLObject.java
@@ -454,10 +454,11 @@ public abstract class DIDLObject {
 
             static public class ICON extends Property<URI> implements NAMESPACE {
                 public ICON() {
+                    this(null);
                 }
 
                 public ICON(URI value) {
-                    super(value, null);
+                    super(value, "icon");
                 }
             }
 


### PR DESCRIPTION
add explicit descriptor name as the automatic detection fails on anonymous classes