### PR TITLE
Some containers will present a UPnP Icon, so include it in the panel.

### DIFF
--- a/workbench/src/main/java/org/fourthline/cling/workbench/plugins/contentdirectory/impl/ContainerFormPanel.java
+++ b/workbench/src/main/java/org/fourthline/cling/workbench/plugins/contentdirectory/impl/ContainerFormPanel.java
@@ -18,7 +18,6 @@ package org.fourthline.cling.workbench.plugins.contentdirectory.impl;
 import org.fourthline.cling.support.model.DIDLObject;
 import org.fourthline.cling.support.model.container.Container;
 import org.fourthline.cling.workbench.plugins.contentdirectory.SelectableFieldsForm;
-import org.seamless.swing.Form;
 
 import javax.swing.JPanel;
 import javax.swing.border.EmptyBorder;
@@ -52,6 +51,9 @@ public class ContainerFormPanel extends JPanel {
         form.addLabelAndSelectableLastField("Child Count:", childCount != null ? childCount.toString() : "-", this);
         form.addLabelAndSelectableLastField("Restricted?", Boolean.toString(container.isRestricted()), this);
         form.addLabelAndSelectableLastField("Searchable?", Boolean.toString(container.isSearchable()), this);
+
+        if (container.hasProperty(DIDLObject.Property.UPNP.ICON.class))
+            form.addLabelAndSelectableLastField("UPnP Icon:", container.getFirstProperty(DIDLObject.Property.UPNP.ICON.class).toString(), this);
 
         if (container.hasProperty(DIDLObject.Property.UPNP.STORAGE_FREE.class))
             form.addLabelAndSelectableLastField("UPnP Storage Free:", container.getFirstProperty(DIDLObject.Property.UPNP.STORAGE_FREE.class).toString(), this);


### PR DESCRIPTION
The current way of adding the fields one by one is too cumbersome.
We should replace the panel with a nice data table that contains all the fields, grouped by their parent (DC, UPNP) and sorted by name.