### PR TITLE
build with jdk 1.8.0_05 and android api 22

### DIFF
--- a/demo/android/pom.xml
+++ b/demo/android/pom.xml
@@ -30,7 +30,7 @@
                         <sdk>
                             <!-- Don't forget to set your ANDROID_HOME environment variable to your SDK directory! -->
                             <path>${env.ANDROID_HOME}</path>
-                            <platform>15</platform>
+                            <platform>22</platform>
                         </sdk>
                         <androidManifestFile>${project.basedir}/src/android/AndroidManifest.xml</androidManifestFile>
                         <resourceDirectory>${project.basedir}/src/android/res</resourceDirectory>

--- a/mediarenderer/src/test/java/org/fourthline/cling/test/mediarenderer/MediaPlayerStateTest.java
+++ b/mediarenderer/src/test/java/org/fourthline/cling/test/mediarenderer/MediaPlayerStateTest.java
@@ -127,7 +127,7 @@ public class MediaPlayerStateTest {
         mp.setVolume(0.50);
         Thread.sleep(500);
         lastChangeExpected =
-                "<Event xmlns=\"urn:schemas-upnp-org:metadata-1-0/AVT_RCS\">" +
+                "<Event xmlns=\"urn:schemas-upnp-org:metadata-1-0/RCS/\">" +
                         "<InstanceID val=\"0\">" +
                         "<Volume channel=\"Master\" val=\"50\"/>" +
                         "</InstanceID>" +
@@ -139,7 +139,7 @@ public class MediaPlayerStateTest {
         mp.setMute(true);
         Thread.sleep(500);
         lastChangeExpected =
-                "<Event xmlns=\"urn:schemas-upnp-org:metadata-1-0/AVT_RCS\">" +
+                "<Event xmlns=\"urn:schemas-upnp-org:metadata-1-0/RCS/\">" +
                         "<InstanceID val=\"0\">" +
                         "<Volume channel=\"Master\" val=\"0\"/>" +
                         "<Mute channel=\"Master\" val=\"1\"/>" +
@@ -152,7 +152,7 @@ public class MediaPlayerStateTest {
         mp.setMute(false);
         Thread.sleep(500);
         lastChangeExpected =
-                "<Event xmlns=\"urn:schemas-upnp-org:metadata-1-0/AVT_RCS\">" +
+                "<Event xmlns=\"urn:schemas-upnp-org:metadata-1-0/RCS/\">" +
                         "<InstanceID val=\"0\">" +
                         "<Volume channel=\"Master\" val=\"50\"/>" +
                         "<Mute channel=\"Master\" val=\"0\"/>" +

--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,7 @@
                     <version>2.10.2</version>
                     <configuration>
                         <quiet>true</quiet>
+                         <additionalparam>-Xdoclint:none</additionalparam>
                     </configuration>
                 </plugin>
 


### PR DESCRIPTION
Hi, 

I tried to build cling from scratch on JDK 1.8.0_05. The javadoc generation became more strict, therefor I had to add an additional parameter in pom.xml. I also had to adjust the MediaPlayerStateTest.java, i assume it contained some typo. 
The demo/android/pom.xml is only changed because I didn't want to download the API for platform 15 and I noticed platform 22 in the manifest as target sdk version already :)

Have a nice day!