### PR TITLE
LogViewImpl injects LogCategories but no bean is defined.

### DIFF
--- a/support/src/main/resources/META-INF/beans.xml
+++ b/support/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://java.sun.com/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:weld="http://jboss.org/schema/weld/beans"
+       xsi:schemaLocation="
+          http://java.sun.com/xml/ns/javaee http://docs.jboss.org/cdi/beans_1_0.xsd
+          http://jboss.org/schema/weld/beans http://jboss.org/schema/weld/beans_1_1.xsd">
+
+    <weld:scan>
+        <weld:exclude name="org.fourthline.cling.support.**"/>
+    </weld:scan>
+</beans>


### PR DESCRIPTION
Excluded package support from weld.

Don't we need to exclude also this package from weld?
