### PR TITLE
consistent subscription values handling; derived new and cached values

### DIFF
--- a/core/src/main/java/org/fourthline/cling/controlpoint/SubscriptionCallback.java
+++ b/core/src/main/java/org/fourthline/cling/controlpoint/SubscriptionCallback.java
@@ -25,11 +25,13 @@ import org.fourthline.cling.model.message.UpnpResponse;
 import org.fourthline.cling.model.meta.LocalService;
 import org.fourthline.cling.model.meta.RemoteService;
 import org.fourthline.cling.model.meta.Service;
+import org.fourthline.cling.model.state.StateVariableValue;
 import org.fourthline.cling.protocol.ProtocolCreationException;
 import org.fourthline.cling.protocol.sync.SendingSubscribe;
 import org.seamless.util.Exceptions;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -162,10 +164,10 @@ public abstract class SubscriptionCallback implements Runnable {
                             }
                         }
 
-                        public void eventReceived() {
+                        public void eventReceived(Map<String, StateVariableValue<?>> changedValues) {
                             synchronized (SubscriptionCallback.this) {
                                 log.fine("Local service state updated, notifying callback, sequence is: " + getCurrentSequence());
-                                SubscriptionCallback.this.eventReceived(this);
+                                SubscriptionCallback.this.eventReceived(this, changedValues);
                                 incrementSequence();
                             }
                         }
@@ -178,7 +180,7 @@ public abstract class SubscriptionCallback implements Runnable {
             localSubscription.establish();
 
             log.fine("Simulating first initial event for local subscription callback, sequence: " + localSubscription.getCurrentSequence());
-            eventReceived(localSubscription);
+            eventReceived(localSubscription, getSubscription().getCurrentValues());
             localSubscription.incrementSequence();
 
             log.fine("Starting to monitor state changes of local service");
@@ -218,9 +220,9 @@ public abstract class SubscriptionCallback implements Runnable {
                         }
                     }
 
-                    public void eventReceived() {
+                    public void eventReceived(Map<String, StateVariableValue<?>> changedValues) {
                         synchronized (SubscriptionCallback.this) {
-                            SubscriptionCallback.this.eventReceived(this);
+                            SubscriptionCallback.this.eventReceived(this, changedValues);
                         }
                     }
 
@@ -312,7 +314,7 @@ public abstract class SubscriptionCallback implements Runnable {
      *
      * @param subscription The established subscription with fresh state variable values.
      */
-    protected abstract void eventReceived(GENASubscription subscription);
+    protected abstract void eventReceived(GENASubscription subscription, Map<String, StateVariableValue<?>> changedValues);
 
     /**
      * Called when a received event was out of sequence, indicating that events have been missed.

--- a/core/src/main/java/org/fourthline/cling/model/gena/GENASubscription.java
+++ b/core/src/main/java/org/fourthline/cling/model/gena/GENASubscription.java
@@ -15,13 +15,13 @@
 
 package org.fourthline.cling.model.gena;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-
 import org.fourthline.cling.model.UserConstants;
 import org.fourthline.cling.model.meta.Service;
 import org.fourthline.cling.model.state.StateVariableValue;
 import org.fourthline.cling.model.types.UnsignedIntegerFourBytes;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * An established subscription, with identifer, expiration duration, sequence handling, and state variable values.
@@ -87,7 +87,7 @@ public abstract class GENASubscription<S extends Service> {
     }
 
     public abstract void established();
-    public abstract void eventReceived();
+    public abstract void eventReceived(Map<String, StateVariableValue<?>> changedValues);
 
     @Override
     public String toString() {

--- a/core/src/main/java/org/fourthline/cling/model/gena/RemoteGENASubscription.java
+++ b/core/src/main/java/org/fourthline/cling/model/gena/RemoteGENASubscription.java
@@ -26,14 +26,12 @@ import org.fourthline.cling.model.UnsupportedDataException;
 
 import java.beans.PropertyChangeSupport;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 
 /**
  * An outgoing subscription to a remote service.
  * <p>
- * Once established, calls its {@link #eventReceived()} method whenever an event has
+ * Once established, calls its {@link #eventReceived(Map)}  method whenever an event has
  * been received from the remote service.
  * </p>
  *
@@ -107,13 +105,14 @@ public abstract class RemoteGENASubscription extends GENASubscription<RemoteServ
 
         this.currentSequence = sequence;
 
+        Map<String, StateVariableValue<?>> changedValues = new HashMap<>(newValues.size());
         for (StateVariableValue newValue : newValues) {
+            changedValues.put(newValue.getStateVariable().getName(), newValue);
             currentValues.put(newValue.getStateVariable().getName(), newValue);
         }
-
-        eventReceived();
+        eventReceived(changedValues);
     }
-    
+
     public abstract void invalidMessage(UnsupportedDataException ex);
 
     public abstract void failed(UpnpResponse responseStatus);

--- a/core/src/main/java/org/fourthline/cling/protocol/sync/ReceivingSubscribe.java
+++ b/core/src/main/java/org/fourthline/cling/protocol/sync/ReceivingSubscribe.java
@@ -25,12 +25,14 @@ import org.fourthline.cling.model.message.gena.IncomingSubscribeRequestMessage;
 import org.fourthline.cling.model.message.gena.OutgoingSubscribeResponseMessage;
 import org.fourthline.cling.model.meta.LocalService;
 import org.fourthline.cling.model.resource.ServiceEventSubscriptionResource;
+import org.fourthline.cling.model.state.StateVariableValue;
 import org.fourthline.cling.protocol.ReceivingSync;
 import org.fourthline.cling.transport.RouterException;
 import org.seamless.util.Exceptions;
 
 import java.net.URL;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Logger;
 
 /**
@@ -135,13 +137,13 @@ public class ReceivingSubscribe extends ReceivingSync<StreamRequestMessage, Outg
             return new OutgoingSubscribeResponseMessage(UpnpResponse.Status.PRECONDITION_FAILED);
         }
 
-        Integer timeoutSeconds; 
+        Integer timeoutSeconds;
         if(getUpnpService().getConfiguration().isReceivedSubscriptionTimeoutIgnored()) {
         	timeoutSeconds = null; // Use default value
         } else {
         	timeoutSeconds = requestMessage.getRequestedTimeoutSeconds();
         }
-        
+
         try {
             subscription = new LocalGENASubscription(service, timeoutSeconds, callbackURLs) {
                 public void established() {
@@ -150,7 +152,7 @@ public class ReceivingSubscribe extends ReceivingSync<StreamRequestMessage, Outg
                 public void ended(CancelReason reason) {
                 }
 
-                public void eventReceived() {
+                public void eventReceived(Map<String, StateVariableValue<?>> changedValues) {
                     // The only thing we are interested in, sending an event when the state changes
                     getUpnpService().getConfiguration().getSyncProtocolExecutorService().execute(
                             getUpnpService().getProtocolFactory().createSendingEvent(this)

--- a/core/src/test/java/example/controlpoint/EventSubscriptionTest.java
+++ b/core/src/test/java/example/controlpoint/EventSubscriptionTest.java
@@ -134,7 +134,7 @@ public class EventSubscriptionTest {
             }
 
             @Override
-            public void eventReceived(GENASubscription sub) {
+            public void eventReceived(GENASubscription sub, Map<String, StateVariableValue<?>> changedValues) {
 
                 System.out.println("Event: " + sub.getCurrentSequence().getValue());
 

--- a/core/src/test/java/example/localservice/EventProviderTest.java
+++ b/core/src/test/java/example/localservice/EventProviderTest.java
@@ -25,12 +25,14 @@ import org.fourthline.cling.model.message.StreamResponseMessage;
 import org.fourthline.cling.model.message.UpnpResponse;
 import org.fourthline.cling.model.meta.LocalDevice;
 import org.fourthline.cling.model.meta.LocalService;
+import org.fourthline.cling.model.state.StateVariableValue;
 import org.fourthline.cling.test.data.SampleData;
 import org.seamless.util.Reflections;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.testng.Assert.*;
 
@@ -121,7 +123,7 @@ public class EventProviderTest extends EventSubscriptionTest {
                 testAssertions.add(true);
             }
 
-            public void eventReceived(GENASubscription subscription) {
+            public void eventReceived(GENASubscription subscription, Map<String, StateVariableValue<?>> changedValues) {
                 if (subscription.getCurrentSequence().getValue() == 0) {
                     assertEquals(subscription.getCurrentValues().get("Status").toString(), "0");
                     testAssertions.add(true);
@@ -194,7 +196,7 @@ public class EventProviderTest extends EventSubscriptionTest {
                 testAssertions.add(true);
             }
 
-            public void eventReceived(GENASubscription subscription) {
+            public void eventReceived(GENASubscription subscription, Map<String, StateVariableValue<?>> changedValues) {
                 if (subscription.getCurrentSequence().getValue() == 0) {
                     assertEquals(subscription.getCurrentValues().get("Target").toString(), "0");
                     assertEquals(subscription.getCurrentValues().get("Status").toString(), "0");
@@ -282,7 +284,7 @@ public class EventProviderTest extends EventSubscriptionTest {
                 testAssertions.add(true);
             }
 
-            public void eventReceived(GENASubscription subscription) {
+            public void eventReceived(GENASubscription subscription, Map<String, StateVariableValue<?>> changedValues) {
                 if (subscription.getCurrentSequence().getValue() == 0) {
 
                     // Initial event contains all evented variables, snapshot of the service state
@@ -396,7 +398,7 @@ public class EventProviderTest extends EventSubscriptionTest {
                 testAssertions.add(true);
             }
 
-            public void eventReceived(GENASubscription subscription) {
+            public void eventReceived(GENASubscription subscription, Map<String, StateVariableValue<?>> changedValues) {
                 if (subscription.getCurrentSequence().getValue() == 0) {
 
                     // Initial event contains all evented variables, snapshot of the service state

--- a/core/src/test/java/org/fourthline/cling/test/gena/EventXMLProcessingTest.java
+++ b/core/src/test/java/org/fourthline/cling/test/gena/EventXMLProcessingTest.java
@@ -37,6 +37,7 @@ import org.testng.annotations.Test;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -96,7 +97,7 @@ public class EventXMLProcessingTest {
         List<URL> urls = new ArrayList<URL>() {{
             add(SampleData.getLocalBaseURL());
         }};
-        
+
         LocalGENASubscription subscription =
                 new LocalGENASubscription(localService, 1800, urls) {
                     public void failed(Exception ex) {
@@ -111,7 +112,7 @@ public class EventXMLProcessingTest {
 
                     }
 
-                    public void eventReceived() {
+                    public void eventReceived(Map<String, StateVariableValue<?>> changedValues) {
 
                     }
                 };

--- a/core/src/test/java/org/fourthline/cling/test/gena/InvalidEventXMLProcessingTest.java
+++ b/core/src/test/java/org/fourthline/cling/test/gena/InvalidEventXMLProcessingTest.java
@@ -156,7 +156,7 @@ public class InvalidEventXMLProcessingTest {
             public void established() {
             }
 
-            public void eventReceived() {
+            public void eventReceived(Map<String, StateVariableValue<?>> changedValues) {
             }
 
             public void invalidMessage(UnsupportedDataException ex) {

--- a/core/src/test/java/org/fourthline/cling/test/gena/OutgoingSubscriptionFailureTest.java
+++ b/core/src/test/java/org/fourthline/cling/test/gena/OutgoingSubscriptionFailureTest.java
@@ -38,7 +38,6 @@ import org.fourthline.cling.model.state.StateVariableValue;
 import org.fourthline.cling.model.types.UnsignedIntegerFourBytes;
 import org.fourthline.cling.protocol.ReceivingSync;
 import org.fourthline.cling.test.data.SampleData;
-import org.fourthline.cling.transport.Router;
 import org.seamless.util.URIUtil;
 import org.testng.annotations.Test;
 
@@ -47,6 +46,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static org.testng.Assert.assertEquals;
 
@@ -109,7 +109,7 @@ public class OutgoingSubscriptionFailureTest {
                 testAssertions.add(false);
             }
 
-            public void eventReceived(GENASubscription subscription) {
+            public void eventReceived(GENASubscription subscription, Map<String, StateVariableValue<?>> changedValues) {
                 testAssertions.add(false);
             }
 
@@ -177,7 +177,7 @@ public class OutgoingSubscriptionFailureTest {
                 testAssertions.add(true);
             }
 
-            public void eventReceived(GENASubscription subscription) {
+            public void eventReceived(GENASubscription subscription, Map<String, StateVariableValue<?>> changedValues) {
                 assertEquals(subscription.getCurrentValues().get("Status").toString(), "0");
                 assertEquals(subscription.getCurrentValues().get("Target").toString(), "1");
                 testAssertions.add(true);

--- a/core/src/test/java/org/fourthline/cling/test/gena/OutgoingSubscriptionLifecycleTest.java
+++ b/core/src/test/java/org/fourthline/cling/test/gena/OutgoingSubscriptionLifecycleTest.java
@@ -39,7 +39,6 @@ import org.fourthline.cling.model.state.StateVariableValue;
 import org.fourthline.cling.model.types.UnsignedIntegerFourBytes;
 import org.fourthline.cling.protocol.ProtocolCreationException;
 import org.fourthline.cling.test.data.SampleData;
-import org.fourthline.cling.transport.RouterException;
 import org.seamless.util.URIUtil;
 import org.testng.annotations.Test;
 
@@ -47,6 +46,7 @@ import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Semaphore;
 
 import static org.testng.Assert.assertEquals;
@@ -103,7 +103,7 @@ public class OutgoingSubscriptionLifecycleTest {
                 testAssertions.add(true);
             }
 
-            public void eventReceived(GENASubscription subscription) {
+            public void eventReceived(GENASubscription subscription, Map<String, StateVariableValue<?>> changedValues) {
                 assertEquals(subscription.getCurrentValues().get("Status").toString(), "0");
                 assertEquals(subscription.getCurrentValues().get("Target").toString(), "1");
                 testAssertions.add(true);
@@ -223,7 +223,7 @@ public class OutgoingSubscriptionLifecycleTest {
             public void ended(GENASubscription subscription, CancelReason reason, UpnpResponse responseStatus) {
             }
 
-            public void eventReceived(GENASubscription subscription) {
+            public void eventReceived(GENASubscription subscription, Map<String, StateVariableValue<?>> changedValues) {
                 assertEquals(subscription.getCurrentValues().get("Status").toString(), "0");
                 assertEquals(subscription.getCurrentValues().get("Target").toString(), "1");
                 testAssertions.add(true);
@@ -252,7 +252,7 @@ public class OutgoingSubscriptionLifecycleTest {
             public void established() {
             }
             @Override
-            public void eventReceived() {
+            public void eventReceived(Map<String, StateVariableValue<?>> changedValues) {
             }
             @Override
             public void invalidMessage(UnsupportedDataException ex) {


### PR DESCRIPTION
LocalGENASubscription and RemoteGENASubscription have inconsistent behaviour.
```currentValues``` are cleared on local (see ```propertyChange``` method in LocalGENASubscription) and preserved on remote (see ```receive``` method in RemoteGENASubscription) subscription event.

This pull request is one of the possibilities of how a consistency can be preserved while also introduces ways to:
- get cached state variable values of GENA subscription (still via ```getCurrentValues```)
- know which of them have changed in the last event (via ```eventReceived``` method modification)