### PR TITLE
Code Quality Improvement - Strings literals should be placed on the left side when checking for equality

### DIFF
--- a/core/src/main/java/org/fourthline/cling/binding/xml/UDA10DeviceDescriptorBinderImpl.java
+++ b/core/src/main/java/org/fourthline/cling/binding/xml/UDA10DeviceDescriptorBinderImpl.java
@@ -186,15 +186,15 @@ public class UDA10DeviceDescriptorBinderImpl implements DeviceDescriptorBinder, 
                 continue;
 
             if (ELEMENT.major.equals(specVersionChild)) {
-                String version = XMLUtil.getTextContent(specVersionChild).trim();
-                if (!version.equals("1")) {
+                String version = XMLUtil.getTextContent(specVersionChild) == null ? "0" : XMLUtil.getTextContent(specVersionChild).trim();
+                if (!"1".equals(version)) {
                     log.warning("Unsupported UDA major version, ignoring: " + version);
                     version = "1";
                 }
                 descriptor.udaVersion.major = Integer.valueOf(version);
             } else if (ELEMENT.minor.equals(specVersionChild)) {
-                String version = XMLUtil.getTextContent(specVersionChild).trim();
-                if (!version.equals("0")) {
+                String version = XMLUtil.getTextContent(specVersionChild) == null ? "0" : XMLUtil.getTextContent(specVersionChild).trim();
+                if (!"0".equals(version)) {
                     log.warning("Unsupported UDA minor version, ignoring: " + version);
                     version = "0";
                 }

--- a/core/src/main/java/org/fourthline/cling/binding/xml/UDA10DeviceDescriptorBinderSAXImpl.java
+++ b/core/src/main/java/org/fourthline/cling/binding/xml/UDA10DeviceDescriptorBinderSAXImpl.java
@@ -137,16 +137,16 @@ public class UDA10DeviceDescriptorBinderSAXImpl extends UDA10DeviceDescriptorBin
         public void endElement(ELEMENT element) throws SAXException {
             switch (element) {
                 case major:
-                    String majorVersion = getCharacters().trim();
-                    if (!majorVersion.equals("1")) {
+                    String majorVersion = getCharacters() == null ? "0" : getCharacters().trim();
+                    if (!"1".equals(majorVersion)) {
                         log.warning("Unsupported UDA major version, ignoring: " + majorVersion);
                         majorVersion = "1";
                     }
                     getInstance().major = Integer.valueOf(majorVersion);
                     break;
                 case minor:
-                    String minorVersion = getCharacters().trim();
-                    if (!minorVersion.equals("0")) {
+                    String minorVersion = getCharacters() == null ? "0" : getCharacters().trim();
+                    if (!"0".equals(minorVersion)) {
                         log.warning("Unsupported UDA minor version, ignoring: " + minorVersion);
                         minorVersion = "0";
                     }

--- a/core/src/main/java/org/fourthline/cling/model/types/Base64Datatype.java
+++ b/core/src/main/java/org/fourthline/cling/model/types/Base64Datatype.java
@@ -30,7 +30,7 @@ public class Base64Datatype extends AbstractDatatype<byte[]> {
     }
 
     public byte[] valueOf(String s) throws InvalidValueException {
-        if (s.equals("")) return null;
+        if (s == null || s.equals("")) return null;
         try {
             return Base64Coder.decode(s);
         } catch (Exception ex) {

--- a/core/src/main/java/org/fourthline/cling/model/types/BinHexDatatype.java
+++ b/core/src/main/java/org/fourthline/cling/model/types/BinHexDatatype.java
@@ -30,7 +30,7 @@ public class BinHexDatatype extends AbstractDatatype<byte[]> {
     }
 
     public byte[] valueOf(String s) throws InvalidValueException {
-        if (s.equals("")) return null;
+        if (s == null || s.equals("")) return null;
         try {
             return HexBin.stringToBytes(s);
         } catch (Exception ex) {

--- a/core/src/main/java/org/fourthline/cling/model/types/BooleanDatatype.java
+++ b/core/src/main/java/org/fourthline/cling/model/types/BooleanDatatype.java
@@ -31,7 +31,7 @@ public class BooleanDatatype extends AbstractDatatype<Boolean> {
     }
 
     public Boolean valueOf(String s) throws InvalidValueException {
-        if (s.equals("")) return null;
+        if (s == null || s.equals("")) return null;
         if (s.equals("1") || s.toUpperCase(Locale.ROOT).equals("YES") || s.toUpperCase(Locale.ROOT).equals("TRUE")) {
             return true;
         } else if (s.equals("0") || s.toUpperCase(Locale.ROOT).equals("NO") || s.toUpperCase(Locale.ROOT).equals("FALSE")) {

--- a/core/src/main/java/org/fourthline/cling/model/types/CharacterDatatype.java
+++ b/core/src/main/java/org/fourthline/cling/model/types/CharacterDatatype.java
@@ -29,7 +29,7 @@ public class CharacterDatatype extends AbstractDatatype<Character> {
     }
 
     public Character valueOf(String s) throws InvalidValueException {
-        if (s.equals("")) return null;
+        if (s == null || s.equals("")) return null;
         return s.charAt(0);
     }
 

--- a/core/src/main/java/org/fourthline/cling/model/types/CustomDatatype.java
+++ b/core/src/main/java/org/fourthline/cling/model/types/CustomDatatype.java
@@ -31,7 +31,7 @@ public class CustomDatatype extends AbstractDatatype<String> {
     }
 
     public String valueOf(String s) throws InvalidValueException {
-        if (s.equals("")) return null;
+        if (s == null || s.equals("")) return null;
         return s;
     }
 

--- a/core/src/main/java/org/fourthline/cling/model/types/DateTimeDatatype.java
+++ b/core/src/main/java/org/fourthline/cling/model/types/DateTimeDatatype.java
@@ -35,7 +35,7 @@ public class DateTimeDatatype extends AbstractDatatype<Calendar> {
     }
 
     public Calendar valueOf(String s) throws InvalidValueException {
-        if (s.equals("")) return null;
+        if (s == null || s.equals("")) return null;
 
         Date d = getDateValue(s, readFormats);
         if (d == null) {

--- a/core/src/main/java/org/fourthline/cling/model/types/DoubleDatatype.java
+++ b/core/src/main/java/org/fourthline/cling/model/types/DoubleDatatype.java
@@ -29,7 +29,7 @@ public class DoubleDatatype extends AbstractDatatype<Double> {
     }
 
     public Double valueOf(String s) throws InvalidValueException {
-        if (s.equals("")) return null;
+        if (s == null || s.equals("")) return null;
         try {
             return Double.parseDouble(s);
         } catch (NumberFormatException ex) {

--- a/core/src/main/java/org/fourthline/cling/model/types/FloatDatatype.java
+++ b/core/src/main/java/org/fourthline/cling/model/types/FloatDatatype.java
@@ -29,7 +29,7 @@ public class FloatDatatype extends AbstractDatatype<Float> {
     }
 
     public Float valueOf(String s) throws InvalidValueException {
-        if (s.equals("")) return null;
+        if (s == null || s.equals("")) return null;
         try {
             return Float.parseFloat(s.trim());
         } catch (NumberFormatException ex) {

--- a/core/src/main/java/org/fourthline/cling/model/types/IntegerDatatype.java
+++ b/core/src/main/java/org/fourthline/cling/model/types/IntegerDatatype.java
@@ -34,7 +34,7 @@ public class IntegerDatatype extends AbstractDatatype<Integer> {
     }
 
     public Integer valueOf(String s) throws InvalidValueException {
-        if (s.equals("")) return null;
+        if (s == null || s.equals("")) return null;
         try {
             Integer value = Integer.parseInt(s.trim());
             if (!isValid(value)) {

--- a/core/src/main/java/org/fourthline/cling/model/types/ShortDatatype.java
+++ b/core/src/main/java/org/fourthline/cling/model/types/ShortDatatype.java
@@ -27,7 +27,7 @@ public class ShortDatatype extends AbstractDatatype<Short> {
     }
 
     public Short valueOf(String s) throws InvalidValueException {
-        if (s.equals("")) return null;
+        if (s == null || s.equals("")) return null;
         try {
             Short value = Short.parseShort(s.trim());
             if (!isValid(value)) {

--- a/core/src/main/java/org/fourthline/cling/model/types/StringDatatype.java
+++ b/core/src/main/java/org/fourthline/cling/model/types/StringDatatype.java
@@ -24,7 +24,7 @@ public class StringDatatype extends AbstractDatatype<String> {
     }
 
     public String valueOf(String s) throws InvalidValueException {
-        if (s.equals("")) return null;
+        if (s == null || s.equals("")) return null;
         return s;
     }
 

--- a/core/src/main/java/org/fourthline/cling/model/types/URIDatatype.java
+++ b/core/src/main/java/org/fourthline/cling/model/types/URIDatatype.java
@@ -27,7 +27,7 @@ public class URIDatatype extends AbstractDatatype<URI> {
     }
 
     public URI valueOf(String s) throws InvalidValueException {
-        if (s.equals("")) return null;
+        if (s == null || s.equals("")) return null;
         try {
             return new URI(s);
         } catch (URISyntaxException ex) {

--- a/core/src/main/java/org/fourthline/cling/model/types/UnsignedIntegerFourBytesDatatype.java
+++ b/core/src/main/java/org/fourthline/cling/model/types/UnsignedIntegerFourBytesDatatype.java
@@ -21,7 +21,7 @@ package org.fourthline.cling.model.types;
 public class UnsignedIntegerFourBytesDatatype extends AbstractDatatype<UnsignedIntegerFourBytes> {
 
     public UnsignedIntegerFourBytes valueOf(String s) throws InvalidValueException {
-        if (s.equals("")) return null;
+        if (s == null || s.equals("")) return null;
         try {
             return new UnsignedIntegerFourBytes(s);
         } catch (NumberFormatException ex) {

--- a/core/src/main/java/org/fourthline/cling/model/types/UnsignedIntegerOneByteDatatype.java
+++ b/core/src/main/java/org/fourthline/cling/model/types/UnsignedIntegerOneByteDatatype.java
@@ -21,7 +21,7 @@ package org.fourthline.cling.model.types;
 public class UnsignedIntegerOneByteDatatype extends AbstractDatatype<UnsignedIntegerOneByte> {
 
     public UnsignedIntegerOneByte valueOf(String s) throws InvalidValueException {
-        if (s.equals("")) return null;
+        if (s == null || s.equals("")) return null;
         try {
             return new UnsignedIntegerOneByte(s);
         } catch (NumberFormatException ex) {

--- a/core/src/main/java/org/fourthline/cling/model/types/UnsignedIntegerTwoBytesDatatype.java
+++ b/core/src/main/java/org/fourthline/cling/model/types/UnsignedIntegerTwoBytesDatatype.java
@@ -21,7 +21,7 @@ package org.fourthline.cling.model.types;
 public class UnsignedIntegerTwoBytesDatatype extends AbstractDatatype<UnsignedIntegerTwoBytes> {
 
     public UnsignedIntegerTwoBytes valueOf(String s) throws InvalidValueException {
-        if (s.equals("")) return null;
+        if (s == null || s.equals("")) return null;
         try {
             return new UnsignedIntegerTwoBytes(s);
         } catch (NumberFormatException ex) {

--- a/core/src/main/java/org/fourthline/cling/transport/impl/FixedSunURLStreamHandler.java
+++ b/core/src/main/java/org/fourthline/cling/transport/impl/FixedSunURLStreamHandler.java
@@ -79,7 +79,7 @@ public class FixedSunURLStreamHandler implements URLStreamHandlerFactory {
             OutputStream os;
             String savedMethod = method;
             // see if the method supports output
-            if (method.equals("PUT") || method.equals("POST") || method.equals("NOTIFY")) {
+            if ("PUT".equals(method) || "POST".equals(method) || "NOTIFY".equals(method)) {
                 // fake the method so the superclass method sets its instance variables
                 method = "PUT";
             } else {

--- a/core/src/main/java/org/fourthline/cling/transport/impl/GENAEventProcessorImpl.java
+++ b/core/src/main/java/org/fourthline/cling/transport/impl/GENAEventProcessorImpl.java
@@ -120,7 +120,7 @@ public class GENAEventProcessorImpl implements GENAEventProcessor, ErrorHandler 
     protected Element readPropertysetElement(Document d) {
 
         Element propertysetElement = d.getDocumentElement();
-        if (propertysetElement == null || !getUnprefixedNodeName(propertysetElement).equals("propertyset")) {
+        if (propertysetElement == null || !"propertyset".equals(getUnprefixedNodeName(propertysetElement))) {
             throw new RuntimeException("Root element was not 'propertyset'");
         }
         return propertysetElement;
@@ -152,7 +152,7 @@ public class GENAEventProcessorImpl implements GENAEventProcessor, ErrorHandler 
             if (propertysetChild.getNodeType() != Node.ELEMENT_NODE)
                 continue;
 
-            if (getUnprefixedNodeName(propertysetChild).equals("property")) {
+            if ("property".equals(getUnprefixedNodeName(propertysetChild))) {
 
                 NodeList propertyChildren = propertysetChild.getChildNodes();
 

--- a/core/src/main/java/org/fourthline/cling/transport/impl/PullSOAPActionProcessorImpl.java
+++ b/core/src/main/java/org/fourthline/cling/transport/impl/PullSOAPActionProcessorImpl.java
@@ -191,9 +191,9 @@ public class PullSOAPActionProcessorImpl extends SOAPActionProcessorImpl {
             event = xpp.next();
             if (event == XmlPullParser.START_TAG) {
                 String tag = xpp.getName();
-                if (tag.equals("errorCode")) {
+                if ("errorCode".equals(tag)) {
                     errorCode = xpp.nextText();
-                } else if (tag.equals("errorDescription")) {
+                } else if ("errorDescription".equals(tag)) {
                     errorDescription = xpp.nextText();
                 }
             }

--- a/core/src/main/java/org/fourthline/cling/transport/impl/SOAPActionProcessorImpl.java
+++ b/core/src/main/java/org/fourthline/cling/transport/impl/SOAPActionProcessorImpl.java
@@ -250,7 +250,7 @@ public class SOAPActionProcessorImpl implements SOAPActionProcessor, ErrorHandle
 
         Element envelopeElement = d.getDocumentElement();
         
-        if (envelopeElement == null || !getUnprefixedNodeName(envelopeElement).equals("Envelope")) {
+        if (envelopeElement == null || !"Envelope".equals(getUnprefixedNodeName(envelopeElement))) {
             throw new RuntimeException("Response root element was not 'Envelope'");
         }
 
@@ -261,7 +261,7 @@ public class SOAPActionProcessorImpl implements SOAPActionProcessor, ErrorHandle
             if (envelopeChild.getNodeType() != Node.ELEMENT_NODE)
                 continue;
 
-            if (getUnprefixedNodeName(envelopeChild).equals("Body")) {
+            if ("Body".equals(getUnprefixedNodeName(envelopeChild))) {
                 return (Element) envelopeChild;
             }
         }
@@ -439,7 +439,7 @@ public class SOAPActionProcessorImpl implements SOAPActionProcessor, ErrorHandle
             if (bodyChild.getNodeType() != Node.ELEMENT_NODE)
                 continue;
 
-            if (getUnprefixedNodeName(bodyChild).equals("Fault")) {
+            if ("Fault".equals(getUnprefixedNodeName(bodyChild))) {
 
                 receivedFaultElement = true;
 
@@ -451,7 +451,7 @@ public class SOAPActionProcessorImpl implements SOAPActionProcessor, ErrorHandle
                     if (faultChild.getNodeType() != Node.ELEMENT_NODE)
                         continue;
 
-                    if (getUnprefixedNodeName(faultChild).equals("detail")) {
+                    if ("detail".equals(getUnprefixedNodeName(faultChild))) {
 
                         NodeList detailChildren = faultChild.getChildNodes();
                         for (int x = 0; x < detailChildren.getLength(); x++) {
@@ -460,7 +460,7 @@ public class SOAPActionProcessorImpl implements SOAPActionProcessor, ErrorHandle
                             if (detailChild.getNodeType() != Node.ELEMENT_NODE)
                                 continue;
 
-                            if (getUnprefixedNodeName(detailChild).equals("UPnPError")) {
+                            if ("UPnPError".equals(getUnprefixedNodeName(detailChild))) {
 
                                 NodeList errorChildren = detailChild.getChildNodes();
                                 for (int y = 0; y < errorChildren.getLength(); y++) {
@@ -469,10 +469,10 @@ public class SOAPActionProcessorImpl implements SOAPActionProcessor, ErrorHandle
                                     if (errorChild.getNodeType() != Node.ELEMENT_NODE)
                                         continue;
 
-                                    if (getUnprefixedNodeName(errorChild).equals("errorCode"))
+                                    if ("errorCode".equals(getUnprefixedNodeName(errorChild)))
                                         errorCode = XMLUtil.getTextContent(errorChild);
 
-                                    if (getUnprefixedNodeName(errorChild).equals("errorDescription"))
+                                    if ("errorDescription".equals(getUnprefixedNodeName(errorChild)))
                                         errorDescription = XMLUtil.getTextContent(errorChild);
                                 }
                             }

--- a/core/src/test/java/org/fourthline/cling/test/model/IncompatibilityTest.java
+++ b/core/src/test/java/org/fourthline/cling/test/model/IncompatibilityTest.java
@@ -215,7 +215,7 @@ public class IncompatibilityTest {
 
         boolean foundA = false;
         for (String s : stateVariable.getTypeDetails().getAllowedValues()) {
-            if (s.equals("A")) foundA = true;
+            if ("A".equals(s)) foundA = true;
         }
         assertEquals(foundA, true);
         assertEquals(stateVariable.getTypeDetails().getAllowedValues().length, 3);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1132 - “Strings literals should be placed on the left side when checking for equality”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1132

Please let me know if you have any questions.

Christian Ivan