### PR TITLE
Increase Android Lock Timeout to over 60 seconds

### DIFF
--- a/core/src/main/java/org/fourthline/cling/android/AndroidRouter.java
+++ b/core/src/main/java/org/fourthline/cling/android/AndroidRouter.java
@@ -74,7 +74,7 @@ public class AndroidRouter extends RouterImpl {
 
     @Override
     protected int getLockTimeoutMillis() {
-        return 15000;
+        return 65000;
     }
 
     @Override


### PR DESCRIPTION
This ensures that there will be no timeouts when shutting down due to other threads having their 60s connection timeouts.