### PR TITLE
Fixed: SendingAction now sets UnsupportedDataException properly as a …

### DIFF
--- a/core/src/main/java/org/fourthline/cling/protocol/sync/SendingAction.java
+++ b/core/src/main/java/org/fourthline/cling/protocol/sync/SendingAction.java
@@ -128,7 +128,7 @@ public class SendingAction extends SendingSync<OutgoingActionRequestMessage, Inc
                 log.fine("Error writing SOAP body: " + ex);
                 log.log(Level.FINE, "Exception root cause: ", Exceptions.unwrap(ex));
             }
-            throw new ActionException(ErrorCode.ACTION_FAILED, "Error writing request message. " + ex.getMessage());
+            throw new ActionException(ErrorCode.ACTION_FAILED.getCode(), "Error writing request message. " + ex.getMessage(), ex);
         }
     }
 
@@ -141,9 +141,9 @@ public class SendingAction extends SendingSync<OutgoingActionRequestMessage, Inc
             log.fine("Error reading SOAP body: " + ex);
             log.log(Level.FINE, "Exception root cause: ", Exceptions.unwrap(ex));
             throw new ActionException(
-                ErrorCode.ACTION_FAILED,
+                ErrorCode.ACTION_FAILED.getCode(),
                 "Error reading SOAP response message. " + ex.getMessage(),
-                false
+                ex
             );
         }
     }
@@ -157,9 +157,9 @@ public class SendingAction extends SendingSync<OutgoingActionRequestMessage, Inc
             log.fine("Error reading SOAP body: " + ex);
             log.log(Level.FINE, "Exception root cause: ", Exceptions.unwrap(ex));
             throw new ActionException(
-                ErrorCode.ACTION_FAILED,
+                ErrorCode.ACTION_FAILED.getCode(),
                 "Error reading SOAP response failure message. " + ex.getMessage(),
-                false
+                ex
             );
         }
     }


### PR DESCRIPTION
…cause to the ActionException. 

I have a bug report saying that
```
Caused by org.fourthline.cling.model.action.ActionException: Error reading SOAP response message. Can't transform null or non-string/zero-length body of: (IncomingActionResponseMessage) 200 OK
       at org.fourthline.cling.protocol.sync.SendingAction.handleResponse(SendingAction.java:145)
       at org.fourthline.cling.protocol.sync.SendingAction.invokeRemote(SendingAction.java:91)
       at org.fourthline.cling.protocol.sync.SendingAction.executeSync(SendingAction.java:63)
       at org.fourthline.cling.protocol.sync.SendingAction.executeSync(SendingAction.java:51)
       at org.fourthline.cling.protocol.SendingSync.execute(SendingSync.java:54)
       at org.fourthline.cling.protocol.SendingAsync.run(SendingAsync.java:54)
       at org.fourthline.cling.controlpoint.ActionCallback.run(ActionCallback.java:151)
       at org.fourthline.cling.support.contentdirectory.callback.Browse.run(Browse.java:89)
```
But it's impossible to see the actual cause. 