### PR TITLE
Multicast port is now configurable.

### DIFF
--- a/core/src/main/java/org/fourthline/cling/DefaultUpnpServiceConfiguration.java
+++ b/core/src/main/java/org/fourthline/cling/DefaultUpnpServiceConfiguration.java
@@ -19,6 +19,7 @@ import org.fourthline.cling.binding.xml.DeviceDescriptorBinder;
 import org.fourthline.cling.binding.xml.ServiceDescriptorBinder;
 import org.fourthline.cling.binding.xml.UDA10DeviceDescriptorBinderImpl;
 import org.fourthline.cling.binding.xml.UDA10ServiceDescriptorBinderImpl;
+import org.fourthline.cling.model.Constants;
 import org.fourthline.cling.model.ModelUtil;
 import org.fourthline.cling.model.Namespace;
 import org.fourthline.cling.model.message.UpnpHeaders;
@@ -89,6 +90,7 @@ public class DefaultUpnpServiceConfiguration implements UpnpServiceConfiguration
     private static Logger log = Logger.getLogger(DefaultUpnpServiceConfiguration.class.getName());
 
     final private int streamListenPort;
+    final private int multicastPort;
 
     final private ExecutorService defaultExecutorService;
 
@@ -111,17 +113,25 @@ public class DefaultUpnpServiceConfiguration implements UpnpServiceConfiguration
     public DefaultUpnpServiceConfiguration(int streamListenPort) {
         this(streamListenPort, true);
     }
+    
+    public DefaultUpnpServiceConfiguration(int streamListenPort, int multicastPort) {
+        this(streamListenPort, multicastPort, true);
+    }
 
     protected DefaultUpnpServiceConfiguration(boolean checkRuntime) {
         this(NetworkAddressFactoryImpl.DEFAULT_TCP_HTTP_LISTEN_PORT, checkRuntime);
     }
-
-    protected DefaultUpnpServiceConfiguration(int streamListenPort, boolean checkRuntime) {
+    protected DefaultUpnpServiceConfiguration(int streamListenPort, boolean checkRuntime)
+    {
+    		this(streamListenPort, Constants.UPNP_MULTICAST_PORT, checkRuntime);
+    }
+    protected DefaultUpnpServiceConfiguration(int streamListenPort, int multicastPort, boolean checkRuntime) {
         if (checkRuntime && ModelUtil.ANDROID_RUNTIME) {
             throw new Error("Unsupported runtime environment, use org.fourthline.cling.android.AndroidUpnpServiceConfiguration");
         }
 
         this.streamListenPort = streamListenPort;
+        this.multicastPort=multicastPort;
 
         defaultExecutorService = createDefaultExecutorService();
 
@@ -254,7 +264,7 @@ public class DefaultUpnpServiceConfiguration implements UpnpServiceConfiguration
     }
 
     public NetworkAddressFactory createNetworkAddressFactory() {
-        return createNetworkAddressFactory(streamListenPort);
+        return createNetworkAddressFactory(streamListenPort, multicastPort);
     }
 
     public void shutdown() {
@@ -262,8 +272,8 @@ public class DefaultUpnpServiceConfiguration implements UpnpServiceConfiguration
         getDefaultExecutorService().shutdownNow();
     }
 
-    protected NetworkAddressFactory createNetworkAddressFactory(int streamListenPort) {
-        return new NetworkAddressFactoryImpl(streamListenPort);
+    protected NetworkAddressFactory createNetworkAddressFactory(int streamListenPort, int multicastPort) {
+        return new NetworkAddressFactoryImpl(streamListenPort, multicastPort);
     }
 
     protected DatagramProcessor createDatagramProcessor() {

--- a/core/src/main/java/org/fourthline/cling/Main.java
+++ b/core/src/main/java/org/fourthline/cling/Main.java
@@ -88,7 +88,7 @@ public class Main {
 
         // This will create necessary network resources for UPnP right away
         System.out.println("Starting Cling...");
-        UpnpService upnpService = new UpnpServiceImpl(listener);
+        UpnpService upnpService = new UpnpServiceImpl(new DefaultUpnpServiceConfiguration(0, 1900),listener);
 
         // Send a search message to all devices and services, they should respond soon
         System.out.println("Sending SEARCH message to all devices...");

--- a/core/src/main/java/org/fourthline/cling/android/AndroidNetworkAddressFactory.java
+++ b/core/src/main/java/org/fourthline/cling/android/AndroidNetworkAddressFactory.java
@@ -40,6 +40,10 @@ public class AndroidNetworkAddressFactory extends NetworkAddressFactoryImpl {
         super(streamListenPort);
     }
 
+    public AndroidNetworkAddressFactory(int streamListenPort, int multicastPort) {
+        super(streamListenPort, multicastPort);
+    }
+
     @Override
     protected boolean requiresNetworkInterface() {
         return false;

--- a/core/src/main/java/org/fourthline/cling/android/AndroidUpnpServiceConfiguration.java
+++ b/core/src/main/java/org/fourthline/cling/android/AndroidUpnpServiceConfiguration.java
@@ -73,8 +73,8 @@ public class AndroidUpnpServiceConfiguration extends DefaultUpnpServiceConfigura
     }
 
     @Override
-    protected NetworkAddressFactory createNetworkAddressFactory(int streamListenPort) {
-        return new AndroidNetworkAddressFactory(streamListenPort);
+    protected NetworkAddressFactory createNetworkAddressFactory(int streamListenPort, int multicastPort) {
+        return new AndroidNetworkAddressFactory(streamListenPort, multicastPort);
     }
 
     @Override

--- a/core/src/main/java/org/fourthline/cling/mock/MockUpnpServiceConfiguration.java
+++ b/core/src/main/java/org/fourthline/cling/mock/MockUpnpServiceConfiguration.java
@@ -67,9 +67,9 @@ public class MockUpnpServiceConfiguration extends DefaultUpnpServiceConfiguratio
     }
 
     @Override
-    protected NetworkAddressFactory createNetworkAddressFactory(int streamListenPort) {
+    protected NetworkAddressFactory createNetworkAddressFactory(int streamListenPort, int multicastPort) {
         // We are only interested in 127.0.0.1
-        return new NetworkAddressFactoryImpl(streamListenPort) {
+        return new NetworkAddressFactoryImpl(streamListenPort, multicastPort) {
             @Override
             protected boolean isUsableNetworkInterface(NetworkInterface iface) throws Exception {
                 return (iface.isLoopback());

--- a/core/src/main/java/org/fourthline/cling/transport/impl/NetworkAddressFactoryImpl.java
+++ b/core/src/main/java/org/fourthline/cling/transport/impl/NetworkAddressFactoryImpl.java
@@ -63,16 +63,19 @@ public class NetworkAddressFactoryImpl implements NetworkAddressFactory {
     final protected List<InetAddress> bindAddresses = new ArrayList<>();
 
     protected int streamListenPort;
-
+    protected int multicastPort;
     /**
      * Defaults to an ephemeral port.
      */
     public NetworkAddressFactoryImpl() throws InitializationException {
         this(DEFAULT_TCP_HTTP_LISTEN_PORT);
     }
-
-    public NetworkAddressFactoryImpl(int streamListenPort) throws InitializationException {
-    	
+    public NetworkAddressFactoryImpl(int streamListenPort) throws InitializationException
+    {
+    		this(streamListenPort, Constants.UPNP_MULTICAST_PORT);
+    }
+    public NetworkAddressFactoryImpl(int streamListenPort, int multicastPort) throws InitializationException {
+    		this.multicastPort=multicastPort;
     	System.setProperty("java.net.preferIPv4Stack", "true");
 
         String useInterfacesString = System.getProperty(SYSTEM_PROPERTY_NET_IFACES);
@@ -134,7 +137,7 @@ public class NetworkAddressFactoryImpl implements NetworkAddressFactory {
     }
 
     public int getMulticastPort() {
-        return Constants.UPNP_MULTICAST_PORT;
+        return multicastPort;
     }
 
     public int getStreamListenPort() {


### PR DESCRIPTION
I use Cling in order to detect the local UPNP router of the lan, and to ask it to open a port with the current computer. I have made some tests, and they work under Linux and under Windows. However, I can't do these tests under MacOS. Here the log of Cling : 

```
org.fourthline.cling.UpnpServiceImpl INFOS : >>> Starting UPnP service...
org.fourthline.cling.UpnpServiceImpl INFOS : Using configuration: com.distrimind.madkit.kernel.network.DefaultUpnpServiceConfiguration
org.fourthline.cling.transport.Router INFOS : Creating Router: org.fourthline.cling.transport.RouterImpl
org.fourthline.cling.transport.spi.MulticastReceiver INFOS : Creating wildcard socket (for receiving multicast datagrams) on port: 1900
org.fourthline.cling.transport.Router GRAVE : Unable to initialize network router: org.fourthline.cling.transport.spi.InitializationException: Could not initialize MulticastReceiverImpl: java.net.BindException: Address already in use
org.fourthline.cling.transport.Router GRAVE : Cause: org.fourthline.cling.transport.spi.InitializationException: Could not initialize MulticastReceiverImpl: java.net.BindException: Address already in use
org.fourthline.cling.UpnpServiceImpl INFOS : <<< UPnP service started successfully
```

It appears that the port 1900 is  officially used by "Back to my mac" on mac OS. But if I make a netstat ou a lsof, no port is opened. 

I have read the code, but there is no possibility to change the multicast port. So I have changed the code to enable it. It does not produce regression and it enables me to open another port than 1900. Then, with these modifications, I can open a port with my UPNP router.

So I propose you to accept this pull request.

Best regards,

Jason. 
