### PR TITLE
Cling Core: Make GENA event XML property order deterministic

### DIFF
--- a/core/src/main/java/org/fourthline/cling/transport/impl/GENAEventProcessorImpl.java
+++ b/core/src/main/java/org/fourthline/cling/transport/impl/GENAEventProcessorImpl.java
@@ -38,6 +38,10 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.FactoryConfigurationError;
 
 import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -129,14 +133,24 @@ public class GENAEventProcessorImpl implements GENAEventProcessor, ErrorHandler 
     /* ##################################################################################################### */
 
     protected void writeProperties(Document d, Element propertysetElement, OutgoingEventRequestMessage message) {
-        for (StateVariableValue stateVariableValue : message.getStateVariableValues()) {
+        List<StateVariableValue> values = new ArrayList<StateVariableValue>(message.getStateVariableValues());
+        
+        Collections.sort(values, new Comparator<StateVariableValue>() {
+            public int compare(StateVariableValue a, StateVariableValue b) {
+                String na = a.getStateVariable().getName();
+                String nb = b.getStateVariable().getName();
+                return nb.compareTo(na);
+            }
+        });
+
+        for (StateVariableValue svv : values) {
             Element propertyElement = d.createElementNS(Constants.NS_UPNP_EVENT_10, "e:property");
             propertysetElement.appendChild(propertyElement);
             XMLUtil.appendNewElement(
                     d,
                     propertyElement,
-                    stateVariableValue.getStateVariable().getName(),
-                    stateVariableValue.toString()
+                    svv.getStateVariable().getName(),
+                    svv.toString()
             );
         }
     }


### PR DESCRIPTION
# Summary
`EventXMLProcessingTest#writeReadRequestPull` was intermittently failing due to non-deterministic ordering of `<e:property>` elements in GENA event XML. This PR makes the output order deterministic.
# Root cause
`GENAEventProcessorImpl#writeProperties(...)` iterated directly over `OutgoingEventRequestMessage#getStateVariableValues()`, which can be backed by an unordered collection. As a result, the emitted `<e:property>` elements sometimes appeared in different orders (e.g., `<SomeVar> … </SomeVar>` before `<Status> … </Status>`), causing assert failures.
# Fix
Copy the collection into a List and sort it before writing:

* Sort List<StateVariableValue> by stateVariable.getName() (descending in this patch) to ensure a stable, predictable order.

* Then emit properties in that order.
# Tests & Verification
* `mvn -pl core -Dtest=org.fourthline.cling.test.gena.EventXMLProcessingTest#writeReadRequestPull test` passes.
* Verified determinism with NonDex: 
  * `mvn -pl core edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=... -DnondexRuns=100`
  * Observed 0 failures across 100 randomized runs after the change.
